### PR TITLE
Added escaping of 7z command

### DIFF
--- a/src/Brainbits/Transcoder/Decoder/SevenzDecoder.php
+++ b/src/Brainbits/Transcoder/Decoder/SevenzDecoder.php
@@ -46,7 +46,7 @@ class SevenzDecoder implements DecoderInterface
      */
     public function decode($data)
     {
-        $command = $this->executable . ' e -an -txz -m0=lzma2 -mx=9 -mfb=64 -md=32m -si -so';
+        $command = escapeshellarg($this->executable) . ' e -an -txz -m0=lzma2 -mx=9 -mfb=64 -md=32m -si -so';
         $process = proc_open($command, [ ['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w'] ], $pipes, null, null);
 
         if (strlen($data)) {

--- a/src/Brainbits/Transcoder/Encoder/SevenzEncoder.php
+++ b/src/Brainbits/Transcoder/Encoder/SevenzEncoder.php
@@ -46,7 +46,7 @@ class SevenzEncoder implements EncoderInterface
      */
     public function encode($data)
     {
-        $command = $this->executable . ' a -an -txz -m0=lzma2 -mx=9 -mfb=64 -md=32m -ms=on -si -so';
+        $command = escapeshellarg($this->executable) . ' a -an -txz -m0=lzma2 -mx=9 -mfb=64 -md=32m -ms=on -si -so';
         $process = proc_open($command, [ ['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w'] ], $pipes, null, null);
 
         $exitCode = 0;


### PR DESCRIPTION
7z command is now escaped to enable command paths with spaces.

Example:
`C:\Program Files\7-Zip\7z.exe`
